### PR TITLE
feat: add GitHub App installation prompt when no installations detected

### DIFF
--- a/apps/dashboard/app/dashboard/page.tsx
+++ b/apps/dashboard/app/dashboard/page.tsx
@@ -15,6 +15,7 @@ import {
   Archive,
   ArrowRight,
   ChevronRight,
+  Github,
 } from "@workspace/ui/icons";
 
 type FilterMode = "turborepo" | "all";
@@ -27,7 +28,8 @@ export default function DashboardPage() {
   const [filter, setFilter] = useState<FilterMode>("turborepo");
 
   const {
-    data: repositories = [],
+    repositories,
+    needsInstallation,
     isLoading: loading,
     error: queryError,
   } = useRepositoriesQuery(!!user && !authLoading);
@@ -291,23 +293,42 @@ export default function DashboardPage() {
           </div>
         )}
 
-        {/* Empty: no repos at all */}
-        {!loading && !error && repositories.length === 0 && (
+        {/* Needs GitHub App installation */}
+        {!loading && !error && needsInstallation && (
+          <div className="flex flex-col items-center justify-center py-20 text-center">
+            <Github className="h-8 w-8 text-zinc-300 dark:text-zinc-600" />
+            <p className="mt-3 text-sm font-medium text-zinc-900 dark:text-zinc-100">
+              Connect your repositories
+            </p>
+            <p className="mt-1 max-w-sm text-xs text-zinc-400 dark:text-zinc-500">
+              Install the TurboGraph app on your GitHub account to select which repositories you&apos;d like to access. Only read-only permissions are required.
+            </p>
+            <a
+              href={`https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_SLUG}/installations/new`}
+              className="mt-4 inline-flex items-center gap-1.5 rounded-lg border border-zinc-200 bg-white px-4 py-2 text-xs font-medium text-zinc-900 transition-colors hover:border-zinc-300 dark:border-zinc-800 dark:bg-zinc-900 dark:text-zinc-100 dark:hover:border-zinc-700"
+            >
+              <Github className="h-3.5 w-3.5" />
+              Install GitHub App
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+        )}
+
+        {/* Empty: no repos at all (app installed but no repos selected) */}
+        {!loading && !error && !needsInstallation && repositories.length === 0 && (
           <div className="flex flex-col items-center justify-center py-20 text-center">
             <Archive className="h-8 w-8 text-zinc-300 dark:text-zinc-600" />
             <p className="mt-3 text-sm font-medium text-zinc-900 dark:text-zinc-100">
               No repositories found
             </p>
             <p className="mt-1 text-xs text-zinc-400 dark:text-zinc-500">
-              You don&apos;t have any repositories yet.
+              No repositories are selected. Update your GitHub App settings to add repositories.
             </p>
             <a
-              href="https://github.com/new"
-              target="_blank"
-              rel="noopener noreferrer"
+              href={`https://github.com/apps/${process.env.NEXT_PUBLIC_GITHUB_APP_SLUG}/installations/new`}
               className="mt-4 inline-flex items-center gap-1.5 text-xs font-medium text-zinc-900 underline underline-offset-2 hover:no-underline dark:text-zinc-100"
             >
-              Create on GitHub
+              Configure repositories
               <ExternalLink className="h-3 w-3" />
             </a>
           </div>

--- a/apps/dashboard/hooks/use-repositories-query.ts
+++ b/apps/dashboard/hooks/use-repositories-query.ts
@@ -9,10 +9,25 @@ export interface RepositoryWithTurbo extends GitHubRepository {
   isTurborepo: boolean;
 }
 
-async function fetchRepositories(): Promise<RepositoryWithTurbo[]> {
+interface RepositoriesResult {
+  repositories: RepositoryWithTurbo[];
+  needsInstallation: boolean;
+}
+
+async function fetchRepositories(): Promise<RepositoriesResult> {
+  const installations = await githubService.getUserInstallations();
+
+  if (installations.length === 0) {
+    return { repositories: [], needsInstallation: true };
+  }
+
   const repos = await githubService.getAccessibleRepositories({
     sort: "updated",
   });
+
+  if (repos.length === 0) {
+    return { repositories: [], needsInstallation: false };
+  }
 
   const repositoriesToCheck = repos.map((repo) => {
     const [owner, name] = repo.full_name.split("/");
@@ -22,18 +37,26 @@ async function fetchRepositories(): Promise<RepositoryWithTurbo[]> {
   const turborepoResults =
     await githubService.batchCheckTurboJson(repositoriesToCheck);
 
-  return repos.map((repo) => ({
+  const repositories = repos.map((repo) => ({
     ...repo,
     isTurborepo: turborepoResults.get(repo.full_name) || false,
   }));
+
+  return { repositories, needsInstallation: false };
 }
 
 export function useRepositoriesQuery(enabled = true) {
-  return useQuery({
+  const query = useQuery({
     queryKey: queryKeys.repositories.userRepos(),
     queryFn: fetchRepositories,
     enabled,
     staleTime: 5 * 60 * 1000, // 5 minutes
     gcTime: 15 * 60 * 1000, // 15 minutes
   });
+
+  return {
+    ...query,
+    repositories: query.data?.repositories ?? [],
+    needsInstallation: query.data?.needsInstallation ?? false,
+  };
 }


### PR DESCRIPTION
Show a "Connect your repositories" prompt with install link when the user has not yet installed the GitHub App. Distinguishes between "needs installation" and "installed but no repos selected" empty states.

Made-with: Cursor